### PR TITLE
fix: branch main, COC v2.1, README headings, scope package name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    timeout-minutes: 6
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        node-version: [24.x, 22.x]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm run build --if-present
+      - run: npm test

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,51 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes
+* Focusing on what is best not just for us as individuals, but for the community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without their explicit permission
+* Other conduct which could reasonably be considered inappropriate professionally
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards
+and will take appropriate and fair corrective action in response to any
+behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement.
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@
 
 ## Install
 
-```
+```sh
 $ npm install @seneca/test-plugin
 ```
 
 ## Quick Example
 
-```
+```sh
 ```
 
 ## More Examples
@@ -50,7 +50,7 @@ The [Senecajs org](https://github.com/senecajs/) encourages open participation. 
 
 ### Running tests
 
-```
+```sh
 npm run test
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The [Senecajs org](https://github.com/senecajs/) encourages open participation. 
 
 ### Running tests
 
-```sh
+```
 npm run test
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@
 [![npm version](https://img.shields.io/npm/v/@seneca/test-plugin.svg)](https://npmjs.com/package/@seneca/test-plugin)
 [![build](https://github.com/senecajs/seneca-test-plugin/actions/workflows/build.yml/badge.svg)](https://github.com/senecajs/seneca-test-plugin/actions/workflows/build.yml)
 [![Known Vulnerabilities](https://snyk.io/test/github/senecajs/seneca-test-plugin/badge.svg)](https://snyk.io/test/github/senecajs/seneca-test-plugin)
-[![Npm][BadgeNpm]][Npm]
-[![Travis][BadgeTravis]][Travis]
-[![Coveralls][BadgeCoveralls]][Coveralls]
 
 | ![Voxgig](https://www.voxgig.com/res/img/vgt01r.png) | This open source module is sponsored and supported by [Voxgig](https://www.voxgig.com). |
 |---|---|
@@ -44,16 +41,7 @@ If you're using this module and need help, you can:
 
 ### Inbound Messages
 
-
-
 ### Implementations
-
-[BadgeCoveralls]: https://coveralls.io/repos/senecajs/seneca-test-plugin/badge.svg?branch=master&service=github
-[BadgeNpm]: https://badge.fury.io/js/senecajs/seneca-test-plugin.svg
-[BadgeTravis]: https://travis-ci.org/senecajs/seneca-test-plugin.svg?branch=master
-[Coveralls]: https://coveralls.io/github/senecajs/seneca-test-plugin?branch=master
-[Npm]: https://www.npmjs.com/package/@seneca/test-plugin
-[Travis]: https://travis-ci.org/senecajs/seneca-test-plugin?branch=master
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
-# @seneca/test-plugin
-[Seneca](senecajs.org) plugin for debugging Seneca-based systems.
+![Seneca](http://senecajs.org/files/assets/seneca-logo.png)
+> A [Seneca.js](http://senecajs.org) plugin
 
+# @seneca/test-plugin
+
+[![npm version](https://img.shields.io/npm/v/@seneca/test-plugin.svg)](https://npmjs.com/package/@seneca/test-plugin)
+[![build](https://github.com/senecajs/seneca-test-plugin/actions/workflows/build.yml/badge.svg)](https://github.com/senecajs/seneca-test-plugin/actions/workflows/build.yml)
+[![Known Vulnerabilities](https://snyk.io/test/github/senecajs/seneca-test-plugin/badge.svg)](https://snyk.io/test/github/senecajs/seneca-test-plugin)
 [![Npm][BadgeNpm]][Npm]
 [![Travis][BadgeTravis]][Travis]
 [![Coveralls][BadgeCoveralls]][Coveralls]
 
+| ![Voxgig](https://www.voxgig.com/res/img/vgt01r.png) | This open source module is sponsored and supported by [Voxgig](https://www.voxgig.com). |
+|---|---|
 
 ## Install
 
@@ -17,14 +24,29 @@ $ npm install @seneca/test-plugin
 ```
 ```
 
+## More Examples
 
-## Inbound Messages
+See [test/](test/) for more usage examples.
+
+## Motivation
+
+[Seneca](http://senecajs.org) plugin for debugging Seneca-based systems.
+
+## Support
+
+If you're using this module and need help, you can:
+
+- Post a [github issue](https://github.com/senecajs/seneca-test-plugin/issues)
+- Tweet to [@senecajs](http://twitter.com/senecajs)
+- Ask on the [Gitter](https://gitter.im/senecajs/seneca)
+
+## API
+
+### Inbound Messages
 
 
 
-## Implementations
-
-
+### Implementations
 
 [BadgeCoveralls]: https://coveralls.io/repos/senecajs/seneca-test-plugin/badge.svg?branch=master&service=github
 [BadgeNpm]: https://badge.fury.io/js/senecajs/seneca-test-plugin.svg
@@ -32,3 +54,17 @@ $ npm install @seneca/test-plugin
 [Coveralls]: https://coveralls.io/github/senecajs/seneca-test-plugin?branch=master
 [Npm]: https://www.npmjs.com/package/@seneca/test-plugin
 [Travis]: https://travis-ci.org/senecajs/seneca-test-plugin?branch=master
+
+## Contributing
+
+The [Senecajs org](https://github.com/senecajs/) encourages open participation. If you feel you can help in any way, be it with documentation, examples, extra testing, or new features please get in touch.
+
+### Running tests
+
+```sh
+npm run test
+```
+
+## Background
+
+Used by the Seneca core team for debugging and testing Seneca-based systems.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![npm version](https://img.shields.io/npm/v/@seneca/test-plugin.svg)](https://npmjs.com/package/@seneca/test-plugin)
 [![build](https://github.com/senecajs/seneca-test-plugin/actions/workflows/build.yml/badge.svg)](https://github.com/senecajs/seneca-test-plugin/actions/workflows/build.yml)
 [![Known Vulnerabilities](https://snyk.io/test/github/senecajs/seneca-test-plugin/badge.svg)](https://snyk.io/test/github/senecajs/seneca-test-plugin)
+[![Coverage Status](https://coveralls.io/repos/senecajs/seneca-test-plugin/badge.svg?branch=master&service=github)](https://coveralls.io/github/senecajs/seneca-test-plugin?branch=master)
 
 | ![Voxgig](https://www.voxgig.com/res/img/vgt01r.png) | This open source module is sponsored and supported by [Voxgig](https://www.voxgig.com). |
 |---|---|


### PR DESCRIPTION
## What changed
- Renamed default branch `master` → `main`
- Added `CODE_OF_CONDUCT.md` v2.1
- Restructured `README.md` with exactly 9 required H1/H2 headings
- Added Voxgig sponsor banner
- Scoped package name
- Added `package-lock.json` to `.gitignore`
- Added `build.yml` GitHub Actions workflow
- Added npm, build and Snyk badges

## Fixes
- `check_default`, `version_codeconduct`, `readme_headings`, `content_readme`, `scoped_package`, `content_gitignore`
